### PR TITLE
feat: update color to account for alternating lines

### DIFF
--- a/bemenu-dracula
+++ b/bemenu-dracula
@@ -1,9 +1,12 @@
-export BEMENU_OPTS="--tb '#6272a4'\
+export BEMENU_OPTS="--scrollbar always\
+ --tb '#6272a4'\
  --tf '#f8f8f2'\
  --fb '#282a36'\
  --ff '#f8f8f2'\
  --nb '#282a36'\
  --nf '#6272a4'\
+ --ab '#282a36'\
+ --af '#6272a4'\
  --hb '#44475a'\
  --hf '#50fa7b'\
  --sb '#44475a'\


### PR DESCRIPTION
https://github.com/Cloudef/bemenu/pull/267 added alternating colors to bemenu. The current Dracula config doesn't support that! This PR fixes that. It also add the scrollbar as a default, since that's what the screenshot on https://draculatheme.com/bemenu suggests.

**Before**
![image](https://github.com/dracula/bemenu/assets/16349988/d5d60475-51ee-47f0-8c14-aaf64aad23ae)


**After**
![image](https://github.com/dracula/bemenu/assets/16349988/3a7e1bc5-42d5-4ebc-88ca-7959f127e41c)
